### PR TITLE
add fix after linters

### DIFF
--- a/terraform/hw4/src/main.tf
+++ b/terraform/hw4/src/main.tf
@@ -1,12 +1,13 @@
 module "test-vm-dev" {
-  source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=4d05fab828b1fcae16556a4d167134efca2fccf2"
   env_name        = "develop"
   network_id      = module.net_dev.network_id
   subnet_zones    = ["ru-central1-a"]
   subnet_ids      = module.net_dev.subnet_ids
   instance_name   = "web"
   image_family    = var.image_family
-  public_ip       = true
+  public_ip       = false
+  security_group_ids = [ module.net_dev.network_id ]
   
   metadata = {
       user-data          = data.template_file.cloudinit.rendered #Для демонстрации №3
@@ -16,14 +17,15 @@ module "test-vm-dev" {
 }
 
 module "test-vm-prod" {
-  source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=4d05fab828b1fcae16556a4d167134efca2fccf2"
   env_name        = "production"
   network_id      = module.net_prod.network_id
   subnet_zones    = ["ru-central1-a"]
   subnet_ids      = module.net_prod.subnet_ids
   instance_name   = "web"
   image_family    = var.image_family
-  public_ip       = true
+  public_ip       = false
+  security_group_ids = [ module.net_dev.network_id ]
   
   metadata = {
       user-data          = data.template_file.cloudinit.rendered #Для демонстрации №3
@@ -56,6 +58,8 @@ module "netology_db_cluster" {
   net_id       = module.net_dev.network_id
   subnet_id    = module.net_dev.subnet_ids[0]
   HA           = false
+  security_group_ids = [ module.net_dev.network_id ]
+
 }
 
 module "netology_db_with_user" {

--- a/terraform/hw4/src/modules/db_cluster/main.tf
+++ b/terraform/hw4/src/modules/db_cluster/main.tf
@@ -13,6 +13,7 @@ resource "yandex_mdb_mysql_cluster" "netology_db_cluster" {
   network_id          = var.net_id
   version             = "8.0"
   deletion_protection = false
+  security_group_ids = var.security_group_ids
 
   resources {
     resource_preset_id = "b1.medium"

--- a/terraform/hw4/src/modules/db_cluster/variables.tf
+++ b/terraform/hw4/src/modules/db_cluster/variables.tf
@@ -21,3 +21,8 @@ variable "HA" {
   default     = false
   description = "Multiple host cluster or single"
 }
+
+variable "security_group_ids" {
+  type = list(string)
+  default = []
+}

--- a/terraform/hw4/src/outputs.tf
+++ b/terraform/hw4/src/outputs.tf
@@ -1,7 +1,7 @@
 output "vault_example" {
- value = "${nonsensitive(data.vault_generic_secret.vault_example.data)}"
+ value = nonsensitive(data.vault_generic_secret.vault_example.data)
 } 
 
 output "vault_database_creds" {
- value = "${nonsensitive(data.vault_generic_secret.vault_database_creds_data.data)}"
+ value = nonsensitive(data.vault_generic_secret.vault_database_creds_data.data)
 } 

--- a/terraform/hw4/src/providers.tf
+++ b/terraform/hw4/src/providers.tf
@@ -2,6 +2,16 @@ terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
+      version = "0.101.0"
+    }
+
+    template = {
+      source = "hashicorp"
+      version = "2.2.0"
+    }
+    vault = {
+      source = "hashicorp"
+      version = "3.21.0"
     }
   }
   required_version = ">=0.13"

--- a/terraform/hw4/src/variables.tf
+++ b/terraform/hw4/src/variables.tf
@@ -19,17 +19,6 @@ variable "default_zone" {
   default     = "ru-central1-a"
   description = "https://cloud.yandex.ru/docs/overview/concepts/geo-scope"
 }
-variable "default_cidr" {
-  type        = list(string)
-  default     = ["10.0.1.0/24"]
-  description = "https://cloud.yandex.ru/docs/vpc/operations/subnet-create"
-}
-
-variable "vpc_name" {
-  type        = string
-  default     = "develop"
-  description = "VPC network&subnet name"
-}
 
 ###common vars
 
@@ -37,20 +26,6 @@ variable "vms_ssh_root_key" {
   type        = string
   default     = "~/.ssh/id_ed25519.pub"
   description = "ssh-keygen -t ed25519"
-}
-
-###example vm_web var
-variable "vm_web_name" {
-  type        = string
-  default     = "netology-develop-platform-web"
-  description = "example vm_web_ prefix"
-}
-
-###example vm_db var
-variable "vm_db_name" {
-  type        = string
-  default     = "netology-develop-platform-db"
-  description = "example vm_db_ prefix"
 }
 
 variable "image_family" {


### PR DESCRIPTION
### tflint
[drzak@laptop src]$ sudo docker run --rm -v $(pwd):/data -t ghcr.io/terraform-linters/tflint
[sudo] пароль для drzak: 
11 issue(s) found:

Warning: Module source "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main" uses a default branch as ref (main) (terraform_module_pinned_source)

  on main.tf line 2:
   2:   source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_module_pinned_source.md

Warning: Module source "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main" uses a default branch as ref (main) (terraform_module_pinned_source)

  on main.tf line 19:
  19:   source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_module_pinned_source.md

Warning: Missing version constraint for provider "template" in `required_providers` (terraform_required_providers)

  on main.tf line 70:
  70: data "template_file" "cloudinit" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_required_providers.md

Warning: [Fixable] Interpolation-only expressions are deprecated in Terraform v0.12.14 (terraform_deprecated_interpolation)

  on outputs.tf line 2:
   2:  value = "${nonsensitive(data.vault_generic_secret.vault_example.data)}"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_deprecated_interpolation.md

Warning: [Fixable] Interpolation-only expressions are deprecated in Terraform v0.12.14 (terraform_deprecated_interpolation)

  on outputs.tf line 6:
   6:  value = "${nonsensitive(data.vault_generic_secret.vault_database_creds_data.data)}"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_deprecated_interpolation.md

Warning: Missing version constraint for provider "yandex" in `required_providers` (terraform_required_providers)

  on providers.tf line 3:
   3:     yandex = {
   4:       source = "yandex-cloud/yandex"
   5:     }

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_required_providers.md

Warning: [Fixable] variable "default_cidr" is declared but not used (terraform_unused_declarations)

  on variables.tf line 22:
  22: variable "default_cidr" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_unused_declarations.md

Warning: [Fixable] variable "vpc_name" is declared but not used (terraform_unused_declarations)

  on variables.tf line 28:
  28: variable "vpc_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_unused_declarations.md

Warning: [Fixable] variable "vm_web_name" is declared but not used (terraform_unused_declarations)

  on variables.tf line 43:
  43: variable "vm_web_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_unused_declarations.md

Warning: [Fixable] variable "vm_db_name" is declared but not used (terraform_unused_declarations)

  on variables.tf line 50:
  50: variable "vm_db_name" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_unused_declarations.md

Warning: Missing version constraint for provider "vault" in `required_providers` (terraform_required_providers)

  on vault.tf line 14:
  14: data "vault_generic_secret" "vault_database_creds_data"{

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.4.0/docs/rules/terraform_required_providers.md


### checkov
terraform scan results:

Passed checks: 3, Failed checks: 7, Skipped checks: 0

Check: CKV_YC_4: "Ensure compute instance does not have serial console enabled."
        PASSED for resource: module.test-vm-dev.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/dev/main.tf:24-73
        Calling File: /main.tf:1-16
Check: CKV_YC_4: "Ensure compute instance does not have serial console enabled."
        PASSED for resource: module.test-vm-prod.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/dev/main.tf:24-73
        Calling File: /main.tf:18-33
Check: CKV_YC_12: "Ensure public IP is not assigned to database cluster."
        PASSED for resource: module.netology_db_cluster.yandex_mdb_mysql_cluster.netology_db_cluster
        File: /modules/db_cluster/main.tf:10-31
        Calling File: /main.tf:53-59
Check: CKV_YC_2: "Ensure compute instance does not have public IP."
        FAILED for resource: module.test-vm-dev.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/dev/main.tf:24-73
        Calling File: /main.tf:1-16

                Code lines for this resource are too many. Please use IDE of your choice to review the file.
Check: CKV_YC_11: "Ensure security group is assigned to network interface."
        FAILED for resource: module.test-vm-dev.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/dev/main.tf:24-73
        Calling File: /main.tf:1-16

                Code lines for this resource are too many. Please use IDE of your choice to review the file.
Check: CKV_YC_2: "Ensure compute instance does not have public IP."
        FAILED for resource: module.test-vm-prod.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/dev/main.tf:24-73
        Calling File: /main.tf:18-33

                Code lines for this resource are too many. Please use IDE of your choice to review the file.
Check: CKV_YC_11: "Ensure security group is assigned to network interface."
        FAILED for resource: module.test-vm-prod.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/dev/main.tf:24-73
        Calling File: /main.tf:18-33

                Code lines for this resource are too many. Please use IDE of your choice to review the file.
Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
        FAILED for resource: test-vm-dev
        File: /main.tf:1-16
        Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/supply-chain-policies/terraform-policies/ensure-terraform-module-sources-use-git-url-with-commit-hash-revision

                1  | module "test-vm-dev" {
                2  |   source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=dev"
                3  |   env_name        = "develop"
                4  |   network_id      = module.net_dev.network_id
                5  |   subnet_zones    = ["ru-central1-a"]
                6  |   subnet_ids      = module.net_dev.subnet_ids
                7  |   instance_name   = "web"
                8  |   image_family    = var.image_family
                9  |   public_ip       = true
                10 |   
                11 |   metadata = {
                12 |       user-data          = data.template_file.cloudinit.rendered #Для демонстрации №3
                13 |       serial-port-enable = 1
                14 |   }
                15 | 
                16 | }

Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
        FAILED for resource: test-vm-prod
        File: /main.tf:18-33
        Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/supply-chain-policies/terraform-policies/ensure-terraform-module-sources-use-git-url-with-commit-hash-revision

                18 | module "test-vm-prod" {
                19 |   source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=dev"
                20 |   env_name        = "production"
                21 |   network_id      = module.net_prod.network_id
                22 |   subnet_zones    = ["ru-central1-a"]
                23 |   subnet_ids      = module.net_prod.subnet_ids
                24 |   instance_name   = "web"
                25 |   image_family    = var.image_family
                26 |   public_ip       = true
                27 |   
                28 |   metadata = {
                29 |       user-data          = data.template_file.cloudinit.rendered #Для демонстрации №3
                30 |       serial-port-enable = 1
                31 |   }
                32 | 
                33 | }

Check: CKV_YC_1: "Ensure security group is assigned to database cluster."
        FAILED for resource: module.netology_db_cluster.yandex_mdb_mysql_cluster.netology_db_cluster
        File: /modules/db_cluster/main.tf:10-31
        Calling File: /main.tf:53-59

                10 | resource "yandex_mdb_mysql_cluster" "netology_db_cluster" {
                11 |   name                = var.cluster_name
                12 |   environment         = "PRODUCTION"
                13 |   network_id          = var.net_id
                14 |   version             = "8.0"
                15 |   deletion_protection = false
                16 | 
                17 |   resources {
                18 |     resource_preset_id = "b1.medium"
                19 |     disk_type_id       = "network-hdd"
                20 |     disk_size          = 10
                21 |   }
                22 | 
                23 |   dynamic "host" {
                24 |     for_each = var.HA ? toset(["1","2","3"]) : toset(["1"])
                25 |     content {
                26 |       zone             = "ru-central1-a"
                27 |       subnet_id        = var.subnet_id
                28 |     }
                29 |     
                30 |   }
                31 | }

secrets scan results:

Passed checks: 0, Failed checks: 0, Skipped checks: 1

Check: CKV_SECRET_6: "Base64 High Entropy String"
        SKIPPED for resource: 24e7451df05ed5cd4cf1041be67c68f8d89d087a
        Suppress comment:  education
        File: /providers.tf:40-41
        Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/secrets-policies/secrets-policy-index/git-secrets-6
